### PR TITLE
Revert "feat(container): update ghcr.io/home-operations/charts-mirror/external-dns ( 1.15.2 → 1.16.0 )"

### DIFF
--- a/kubernetes/apps/networking/cloudflare-dns/app/repository.yaml
+++ b/kubernetes/apps/networking/cloudflare-dns/app/repository.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.16.0
+    tag: 1.15.2
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign


### PR DESCRIPTION
Reverts kashalls/home-cluster#3425