### PR TITLE
feat(gpu): enable Intel Arc A310 and share it with Plex + Immich ML

### DIFF
--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -17,6 +17,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [44] # render group for /dev/dri
     controllers:
       immich:
         strategy: RollingUpdate
@@ -56,7 +57,7 @@ spec:
           main:
             image:
               repository: ghcr.io/immich-app/immich-machine-learning
-              tag: v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+              tag: v2.7.5-openvino
             env:
               REDIS_HOSTNAME: *redisHostname
               MPLCONFIGDIR: "/cache/matplotlib"
@@ -168,3 +169,10 @@ spec:
                 subPath: geocoding
               - path: /usr/src/app/.transformers_cache
                 subPath: transformers
+      dev-dri:
+        type: hostPath
+        hostPath: /dev/dri
+        advancedMounts:
+          machine-learning:
+            main:
+              - path: /dev/dri

--- a/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
@@ -65,6 +65,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [44] # render group for /dev/dri
     service:
       app:
         controller: plex
@@ -122,5 +123,10 @@ spec:
         globalMounts:
           - path: /media
             readOnly: true
+      dev-dri:
+        type: hostPath
+        hostPath: /dev/dri
+        globalMounts:
+          - path: /dev/dri
       tmp:
         type: emptyDir

--- a/talos/nodes/10.0.10.40.yaml
+++ b/talos/nodes/10.0.10.40.yaml
@@ -2,7 +2,7 @@
 machine:
   type: controlplane
   install:
-    image: factory.talos.dev/metal-installer/4dc56e498c4dd5c3d64aac5f26aed9f920658f54f3588f25605ac2fb56ad7fa9:{{ ENV.TALOS_VERSION }}
+    image: factory.talos.dev/metal-installer/0d5c45fad11b1770393092f64cf31d3cd212d8e5973d706e9c7114c017eb4695:{{ ENV.TALOS_VERSION }}
     diskSelector:
       serial: 50026B76878F13D4
 ---

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -9,4 +9,6 @@ customization:
     systemExtensions:
         officialExtensions:
             - siderolabs/amd-ucode
+            - siderolabs/i915
+            - siderolabs/mei
             - siderolabs/zfs


### PR DESCRIPTION
## Summary
Brings up the newly installed Intel Arc A310 on `puddle` and shares it between Plex (transcode) and Immich ML (OpenVINO), no device plugin.

## Changes
- **Talos schematic**: add `siderolabs/i915` (DG2 driver + GuC/HuC firmware) and `siderolabs/mei` (Intel ME, prerequisite for discrete Arc); repoint installer image at new schematic `0d5c45fad11b1770393092f64cf31d3cd212d8e5973d706e9c7114c017eb4695`.
- **Plex**: mount `/dev/dri`, add `supplementalGroups: [44]` (render).
- **Immich ML**: switch to `-openvino` image, mount `/dev/dri` into the ML pod, add render group.

Both pods open `renderD128` directly; the kernel time-slices concurrent access, and the two workloads mostly hit different engine blocks (media vs compute EUs).

## Applied to node
The `i915`/`mei` extensions and ReBAR are already live on `puddle` (upgraded + BIOS ReBAR enabled): driver bound at `0000:83:00.0`, firmware authenticated, full 4 GiB BAR.

## Post-merge verification
- Plex: confirm `(hw)` transcode in the dashboard.
- Immich: ML pod logs show the OpenVINO provider, not CPU.

> Note: dropped the ML image digest (it pinned the CPU image); Renovate will re-pin the openvino tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)