### PR TITLE
feat(entertainment): add manga stack (suwayomi, mangarr, kavita)

### DIFF
--- a/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kavita
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: kavita
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      kavita:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/kareadita/kavita
+              tag: 0.9.0.2@sha256:880a8feff0833e860575f8e08788e4b4f59f8659afd17206566aae88a525130d
+            env:
+              TZ: America/Los_Angeles
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &port 5000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 15m
+                memory: 300Mi
+              limits:
+                memory: 4Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: kavita
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.ok8.sh"]
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: openebs-hostpath
+        globalMounts:
+          - path: /kavita/config
+      media:
+        type: hostPath
+        hostPath: /var/mnt/puddle/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/entertainment/kavita/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/kavita/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kavita
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/kavita/ks.yaml
+++ b/kubernetes/apps/entertainment/kavita/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kavita
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/kavita/app
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./kavita/ks.yaml
+  - ./mangarr/ks.yaml
   - ./prowlarr/ks.yaml
   - ./plex/ks.yaml
   - ./qbittorrent/ks.yaml
@@ -21,5 +23,6 @@ resources:
   - ./sabnzbd/ks.yaml
   - ./seerr/ks.yaml
   - ./sonarr/ks.yaml
+  - ./suwayomi/ks.yaml
   - ./tautulli/ks.yaml
   - ./thelounge/ks.yaml

--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mangarr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: mangarr
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      mangarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/mangarr
+              tag: sha-79dc68b@sha256:ead7fc49064bb35b8f5b9ca4bf5413cf4847f79efad40586ac5c263a7192a5d5
+            env:
+              TZ: America/Los_Angeles
+              MANGARR_DOWNLOAD_ROOTS: /media/Downloads/suwayomi
+              MANGARR_DB_PATH: /config/mangarr.db
+              MANGARR_HTTP_ADDR: :8590
+              # Recycle bin must live on the SAME filesystem as the media it
+              # bins — /media is the shared hostPath (downloads + library),
+              # /config is a separate PVC, so a bin under /config would fail
+              # os.Rename with "invalid cross-device link" on delete-with-files.
+              MANGARR_RECYCLE_BIN_PATH: /media/Downloads/.recyclebin
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8590
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: mangarr
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.ok8.sh"]
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: openebs-hostpath
+        globalMounts:
+          - path: /config
+      media:
+        type: hostPath
+        hostPath: /var/mnt/puddle/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/entertainment/mangarr/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/mangarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mangarr
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/mangarr/ks.yaml
+++ b/kubernetes/apps/entertainment/mangarr/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mangarr
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/mangarr/app
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/entertainment/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/app/helmrelease.yaml
@@ -1,0 +1,175 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: suwayomi
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: suwayomi
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      suwayomi:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Seed server.conf onto the writable PVC. Suwayomi's entrypoint runs
+          # sed -i against server.conf which fails on a configMap subPath bind
+          # mount ('Device or resource busy' during atomic rename). Copying the
+          # ConfigMap into the PVC sidesteps the bind-mount restriction while
+          # keeping the config in git via Reloader.
+          01-init-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                cp /configmap/server.conf /tachidesk-data/server.conf
+                # Suwayomi refuses to start with server.downloadsPath pointing
+                # at a non-existent directory; pre-create it on shared media.
+                mkdir -p /media/Downloads/suwayomi
+        containers:
+          app:
+            image:
+              repository: ghcr.io/suwayomi/tachidesk
+              tag: v2.3.2259@sha256:2556d81e3370ddf76af028bb5d49b6857a839aea10b5d027a11e74a44d1fe83e
+            env:
+              TZ: America/Los_Angeles
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 4567
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: suwayomi
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.ok8.sh"]
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: openebs-hostpath
+        advancedMounts:
+          suwayomi:
+            01-init-config:
+              - path: /tachidesk-data
+            app:
+              - path: /home/suwayomi/.local/share/Tachidesk
+      config-file:
+        type: configMap
+        name: suwayomi
+        advancedMounts:
+          suwayomi:
+            01-init-config:
+              - path: /configmap
+                readOnly: true
+      media:
+        type: hostPath
+        hostPath: /var/mnt/puddle/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir
+    configMaps:
+      config:
+        data:
+          server.conf: |
+            # Suwayomi-Server config. Database is the embedded H2 default.
+
+            # === Networking ===
+            server.ip = "0.0.0.0"
+            server.port = 4567
+
+            # === Auth (internal-only; enable later if needed) ===
+            server.authMode = "none"
+
+            # === Downloads ===
+            server.downloadAsCbz = true
+            server.downloadsPath = "/media/Downloads/suwayomi"
+            server.autoDownloadNewChapters = true
+            server.excludeEntryWithUnreadChapters = false
+            server.autoDownloadNewChaptersLimit = 0
+            server.autoDownloadIgnoreReUploads = true
+
+            # === Global update (scheduled new-chapter checks) ===
+            # "Pull everything" stance: don't skip series we're behind on or
+            # haven't started. globalUpdateInterval is hours (minimum 6).
+            server.globalUpdateInterval = 12
+            server.excludeUnreadChapters = false
+            server.excludeNotStarted = false
+            server.excludeCompleted = false
+            server.updateMangas = false
+
+            # === FlareSolverr (not deployed in this cluster) ===
+            server.flareSolverrEnabled = false
+
+            # === Web UI ===
+            server.webUIEnabled = true
+            server.initialOpenInBrowserEnabled = false
+            server.webUIInterface = "browser"
+            server.webUIFlavor = "WebUI"
+            server.webUIChannel = "STABLE"
+            server.webUIUpdateCheckInterval = 23
+
+            # === Pre-seeded extension repos (Keiyoushi + Yuzono) ===
+            server.extensionRepos = [
+              "https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json",
+              "https://raw.githubusercontent.com/yuzonomanga/yuzono-extensions/repo/index.min.json"
+            ]
+
+            # === Misc ===
+            server.debugLogsEnabled = false
+            server.systemTrayEnabled = false
+            server.maxSourcesInParallel = 6
+            server.maxLogFiles = 14
+            server.maxLogFileSize = "10mb"
+            server.maxLogFolderSize = "100mb"

--- a/kubernetes/apps/entertainment/suwayomi/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/suwayomi/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: suwayomi
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/suwayomi/ks.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app suwayomi
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/suwayomi/app
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## What

Adds a manga pipeline to the `entertainment` namespace, adapted from [gavinmcfall/home-ops](https://github.com/gavinmcfall/home-ops):

- **suwayomi** — Mihon/Tachiyomi server; downloads chapters as CBZ to `/media/Downloads/suwayomi`. server.conf is seeded onto the PVC by an init container (Suwayomi's entrypoint runs `sed -i` on it, which fails on a configMap bind mount). Extension repos (Keiyoushi + Yuzono) pre-seeded.
- **mangarr** — watches the Suwayomi download root, classifies series by type via AniList, files them into `/media/Library/Books/<type>`, and triggers Kavita scans. Recycle bin kept on `/media` (same filesystem) to avoid cross-device rename failures.
- **kavita** — reader serving `/media/Library/Books`.

## Why

Manga acquisition/reading with the same GitOps conventions as the rest of the *arr stack. qBittorrent is not involved — Suwayomi downloads over HTTP via source extensions.

## Reviewer notes

- Follows the existing sonarr pattern: app-template 5.0.1 via OCIRepository, inline config PVC (renders as bare app name, so the volsync component's `${APP}` ReplicationSource matches), uid 1000, `{app}.ok8.sh` on the internal gateway, media via hostPath.
- Deviations from upstream: embedded H2 instead of CNPG Postgres, FlareSolverr disabled (not deployed here), Kavita on the internal gateway and forced to uid 1000 instead of upstream's root default — if Kavita crashloops, drop its `defaultPodOptions.securityContext`.
- Validated with `kustomize build` and `helm template` (resource naming confirmed against live PVC conventions).
- First reconcile will log one failed volsync restore-once per app (no backups exist yet) — expected.
- Post-deploy one-time setup: create `/media/Library/Books/{Manga,Manhwa,Manhua}`, set up Kavita admin + libraries, then point mangarr settings at the library roots and Kavita URL/API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)