### PR TITLE
fix(kopia-b2): grant DAC_READ_SEARCH to read 0700 projects/kashall dir

### DIFF
--- a/kubernetes/apps/volsync-system/kopia-b2/app/cronjob.yaml
+++ b/kubernetes/apps/volsync-system/kopia-b2/app/cronjob.yaml
@@ -91,7 +91,9 @@ spec:
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
-                capabilities: {drop: ["ALL"]}
+                # DAC_READ_SEARCH lets root traverse/read 0700 dirs (e.g. projects/kashall)
+                # despite dropping ALL; all mounts are readOnly so no write bypass is granted.
+                capabilities: {add: ["DAC_READ_SEARCH"], drop: ["ALL"]}
               volumeMounts:
                 # Image expects config/cache/logs under /config (KOPIA_CONFIG_PATH etc.)
                 - name: scratch


### PR DESCRIPTION
## Summary
- The weekly kopia-b2 backup job (`volsync-system/kopia-b2`) has been failing every run since it was added: `kopia snapshot create` hit `permission denied` traversing `/data/projects/kashall`, which is `0700` on the host.
- The container runs as `runAsUser: 0` but drops all capabilities, which strips `DAC_READ_SEARCH`/`DAC_OVERRIDE` — so root can no longer bypass file permission bits, and gets denied by the `0700` mode like any other user.
- Adds `DAC_READ_SEARCH` back (not the broader `DAC_OVERRIDE`) so root can traverse/read but not write, matching the fact that all data mounts are already `readOnly: true`.

## Test plan
- [x] Suspended the `kopia-b2` Flux Kustomization, applied the patched CronJob directly, and ran a manual test job (`kopia-b2-manual-test-1785296445`) against the live cluster.
- [x] Job completed with exit 0; the new `/data/projects` snapshot shows `errors:1` gone and 11 more files / 2 more dirs picked up (the previously-unreadable `kashall` subtree).
