### PR TITLE
feat(entertainment): add flaresolverr for suwayomi cloudflare bypass

### DIFF
--- a/kubernetes/apps/entertainment/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/flaresolverr/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flaresolverr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: flaresolverr
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      flaresolverr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/flaresolverr/flaresolverr
+              tag: v3.5.0@sha256:139dfee1c6f89249c8d665d1333a42e8ec74ec0a86bc6bb1c8461e10d3a66a47
+            env:
+              TZ: America/Los_Angeles
+              LOG_LEVEL: info
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8191
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 15m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    service:
+      app:
+        controller: flaresolverr
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/entertainment/flaresolverr/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/flaresolverr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/flaresolverr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/flaresolverr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flaresolverr
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/flaresolverr/ks.yaml
+++ b/kubernetes/apps/entertainment/flaresolverr/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app flaresolverr
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/flaresolverr/app
+  prune: true
+  retryInterval: 2m
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./flaresolverr/ks.yaml
   - ./kavita/ks.yaml
   - ./mangarr/ks.yaml
   - ./prowlarr/ks.yaml

--- a/kubernetes/apps/entertainment/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/app/helmrelease.yaml
@@ -149,8 +149,13 @@ spec:
             server.excludeCompleted = false
             server.updateMangas = false
 
-            # === FlareSolverr (not deployed in this cluster) ===
-            server.flareSolverrEnabled = false
+            # === FlareSolverr (cluster-local service) ===
+            server.flareSolverrEnabled = true
+            server.flareSolverrUrl = "http://flaresolverr.entertainment.svc.cluster.local:8191"
+            server.flareSolverrTimeout = 60
+            server.flareSolverrSessionName = "suwayomi"
+            server.flareSolverrSessionTtl = 15
+            server.flareSolverrAsResponseFallback = false
 
             # === Web UI ===
             server.webUIEnabled = true


### PR DESCRIPTION
## What

- **flaresolverr** in `entertainment`: cluster-internal only (ClusterIP, no route/PVC/volsync — stateless), single replica, `/health` probes.
- Suwayomi's `server.conf` ConfigMap updated to enable FlareSolverr pointing at `http://flaresolverr.entertainment.svc.cluster.local:8191`.

## Why

Cloudflare-fronted manga sources (Asura Scans et al.) fail in Suwayomi without a FlareSolverr backend.

## Reviewer notes

- The ConfigMap change is mostly documentation: current Suwayomi stores settings in its database, so the live toggle is applied via its GraphQL API (done out-of-band). The conf value only matters for a fresh install import.
- No securityContext hardening on flaresolverr — it runs headless Chromium, which breaks under readOnlyRootFilesystem/non-root constraints; matches the proven upstream config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)