### PR TITLE
feat(custom-apps): scaffold apis single-binary app

### DIFF
--- a/kubernetes/apps/custom-apps/apis/app/externalsecret.yaml
+++ b/kubernetes/apps/custom-apps/apis/app/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apis
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: apis-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # TRMNL private plugin webhook URLs.
+        TRMNL_TEXT_WEBHOOK_URL: "{{ .TRMNL_TEXT_WEBHOOK_URL }}"
+        TRMNL_IMAGE_WEBHOOK_URL: "{{ .TRMNL_IMAGE_WEBHOOK_URL }}"
+        HOME_ASSISTANT_BASE_URL: "http://home-assistant.default.svc.cluster.local:8123"
+        HOME_ASSISTANT_TOKEN: "{{ .HOME_ASSISTANT_TOKEN }}"
+        HOME_ASSISTANT_LIGHT_GROUP: "{{ .HOME_ASSISTANT_LIGHT_GROUP }}"
+        SPOTIFY_CLIENT_ID: "{{ .SPOTIFY_CLIENT_ID }}"
+        SPOTIFY_CLIENT_SECRET: "{{ .SPOTIFY_CLIENT_SECRET }}"
+        SPOTIFY_REDIRECT_URI: "https://api.ok8.sh/api/spotify/setup"
+        REDIS_URL: "redis://dragonfly.custom-apps.svc.cluster.local:6379/0"
+        GITHUB_USERNAME: "kashalls"
+        GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: trmnl
+    - extract:
+        key: home-assistant-api
+    - extract:
+        key: spotify
+    - extract:
+        key: github

--- a/kubernetes/apps/custom-apps/apis/app/helmrelease.yaml
+++ b/kubernetes/apps/custom-apps/apis/app/helmrelease.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app apis
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      apis:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/kashalls/apis
+              # TODO: pin to rolling@sha256:... once kashalls/apis#11 merges
+              # and ghcr.io/kashalls/apis publishes.
+              tag: rolling
+            env:
+              TZ: America/Los_Angeles
+              PUBLIC_BASE_URL: "https://api.ok8.sh"
+              TRUSTED_PROXY_CIDRS: "10.0.20.0/24,172.30.0.0/16"
+            envFrom:
+              - secretRef:
+                  name: apis-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 192Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: apis
+        ports:
+          http:
+            port: &port 8080
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
+        hostnames: ["api.ok8.sh"]
+        parentRefs:
+          - name: external
+            namespace: networking
+            sectionName: https
+        rules:
+          - matches:
+              - path: { type: PathPrefix, value: /api }
+            backendRefs:
+              - name: *app
+                port: *port
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: openebs-hostpath
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/custom-apps/apis/app/kustomization.yaml
+++ b/kubernetes/apps/custom-apps/apis/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/custom-apps/apis/app/ocirepository.yaml
+++ b/kubernetes/apps/custom-apps/apis/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: apis
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/custom-apps/apis/ks.yaml
+++ b/kubernetes/apps/custom-apps/apis/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app apis
+  namespace: &namespace custom-apps
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: apirouter
+      namespace: custom-apps
+  path: ./kubernetes/apps/custom-apps/apis/app
+  prune: true
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/custom-apps/kustomization.yaml
+++ b/kubernetes/apps/custom-apps/kustomization.yaml
@@ -9,6 +9,7 @@ replacements:
   - path: ../../components/replacements/ks.yaml
 resources:
   - ./apirouter/ks.yaml
+  - ./apis/ks.yaml
   - ./home-assistant-api/ks.yaml
   - ./juno/ks.yaml
   - ./ok8-sh/ks.yaml


### PR DESCRIPTION
## Summary

Prep for [kashalls/apis#11](https://github.com/kashalls/apis/pull/11), which merges the separate `trmnl` and `homeassistant` binaries/images into a single `ghcr.io/kashalls/apis` binary/image, adds `spotify` and `github` services, and moves every route under its own `/api/<service>` prefix.

- Adds a new `custom-apps/apis` HelmRelease/ExternalSecret/OCIRepository, routed on `api.ok8.sh` at `PathPrefix /api`, which will serve `/api/trmnl`, `/api/homeassistant`, `/api/spotify`, `/api/github`.
- **Runs alongside** the existing `trmnl` and `home-assistant-api` apps (still on their current `/trmnl` and `/home-assistant` routes) — additive only, nothing currently serving traffic is touched.
- Combines env config for all four integrations into one `apis-secret` ExternalSecret, reusing the existing `trmnl` and `home-assistant-api` 1Password items and adding two new `dataFrom` extracts (`spotify`, `github`).
- `REDIS_URL` points at the `dragonfly` Dragonfly instance already provisioned by `custom-apps/apirouter` (used for spotify's OAuth token cache and github's response cache).

## Not done here (follow-up once #11 merges)

- `ghcr.io/kashalls/apis` doesn't exist yet, so the image tag is left as unpinned `rolling` — the HelmRelease will fail to pull until the image publishes. This is expected; it doesn't affect the existing `trmnl`/`home-assistant-api` apps.
- Needs two new 1Password items before the ExternalSecret will fully sync: `spotify` (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`) and `github` (`GITHUB_TOKEN`).
- Once the image is published and verified working, pin the digest and remove the old `trmnl`/`home-assistant-api` apps in a follow-up cleanup PR.

## Test plan

- [x] `kustomize build kubernetes/apps/custom-apps/apis/app` — builds cleanly
- [x] `kustomize build kubernetes/apps/custom-apps` — parent kustomization resolves the new app with correct namespace/labels
- [ ] Flux reconcile against the live cluster (expected to stay pending on the HelmRelease until the image publishes)
