### PR TITLE
Raise near-limit memory ceilings and drop unused apiserver histogram series

### DIFF
--- a/kubernetes/apps/networking/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/echo/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
-                memory: 64Mi
+                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -171,4 +171,4 @@ spec:
       requests:
         cpu: 10m
       limits:
-        memory: 64Mi
+        memory: 128Mi

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -59,6 +59,19 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
+    kubeApiServer:
+      serviceMonitor:
+        # Overrides the chart default relabelings, which only trim le buckets
+        metricRelabelings:
+          # Histogram families unused by any dashboard, recording rule, or alert
+          - action: drop
+            sourceLabels: ["__name__"]
+            regex: (apiserver_request_duration_seconds|apiserver_request_body_size_bytes|etcd_request_duration_seconds|apiserver_watch_list_duration_seconds|apiserver_watch_cache_read_wait_seconds|apiserver_response_sizes|apiserver_watch_events_sizes)_bucket
+          # Chart default trim, kept for the SLI histogram that feeds the
+          # KubeAPIErrorBudgetBurn recording rules
+          - action: drop
+            sourceLabels: ["__name__", "le"]
+            regex: (apiserver_request_slo|apiserver_request_sli)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|40|45|50)(\.0)?
     kubeScheduler:
       service:
         selector:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
           requests:
             cpu: 250m
           limits:
-            memory: 2048Mi
+            memory: 3072Mi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## What changed

- **Memory limit bumps** for three containers that peaked above 80% of their limit over the last 7 days:
  - echo: 64Mi → 128Mi (peaked at 98.5%)
  - kromgo: 64Mi → 128Mi (87%)
  - Prometheus: 2048Mi → 3072Mi (83%)
- **Drop unused apiserver histogram buckets** via `kubeApiServer.serviceMonitor.metricRelabelings` in kube-prometheus-stack: seven bucket families (`apiserver_request_duration_seconds`, `apiserver_request_body_size_bytes`, `etcd_request_duration_seconds`, `apiserver_watch_list_duration_seconds`, `apiserver_watch_cache_read_wait_seconds`, `apiserver_response_sizes`, `apiserver_watch_events_sizes`) totaling ~32k of 213k head series.

## Why

The tight limits were one burst away from OOMKills; the combined bump is ~1.1GiB against the ~32GiB k8s/system reserve carved out next to the ZFS ARC cap. The dropped histograms are referenced by no dashboard, recording rule, or alert (verified against all 45 PrometheusRules in the cluster and every dashboard querying apiserver metrics).

## Reviewer notes

- Overriding `metricRelabelings` replaces the chart default, so the default `le`-bucket trim is re-included for the SLI/SLO duration histograms. `apiserver_request_sli_duration_seconds_bucket` is kept intact since the KubeAPIErrorBudgetBurn recording rules consume it (44 references).
- ServiceMonitor rendering validated with `helm template` against chart 88.3.0 using the repo values; kustomize builds pass.
- Head series should settle around ~180k a few hours after Flux applies this.