### PR TITLE
Fix victoria-logs-collector OOM crashloop on rollout

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -40,4 +40,7 @@ spec:
       requests:
         cpu: 10m
       limits:
-        memory: 256Mi
+        # Initial/catch-up ingestion of the full /var/log/pods backlog spikes
+        # far above the tiny steady-state footprint; 256Mi OOMKilled on first
+        # rollout before the checkpoint file could ever be written
+        memory: 1Gi


### PR DESCRIPTION
## What changed

Raises the victoria-logs-collector memory limit from 256Mi to 1Gi.

## Why

The collector never rolled out after #5550: vlagent was OOMKilled within one second of startup, 10 restarts in its first 26 minutes. On first run it has no checkpoint file, so it ingests the entire `/var/log/pods` backlog (pods up to 45 days old) at full speed, and the allocation spike blows through 256Mi before the checkpoint is ever written — so every restart starts the backlog over, crashlooping forever. vlagent is cgroup-aware for its caches (60% of the limit) but its initial ingestion buffers overshoot.

Steady-state usage is tens of MB; the headroom is for first rollout and post-outage catch-up, which is exactly when the disk-buffered remote write needs to drain. Upstream ships the chart with no limits; the 256Mi was added in #5550 and was too tight.

## Reviewer notes

Once merged, the pod should ingest the backlog (a few minutes of elevated memory/CPU), write its checkpoint, and settle. If it OOMs even at 1Gi the next lever is `VL_` env `memory.allowedPercent`, but that shouldn't be needed.