### PR TITLE
Fix victoria-logs server OOM during backlog ingest

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -37,7 +37,10 @@ spec:
         requests:
           cpu: 100m
         limits:
-          memory: 1Gi
+          # Bulk ingest (initial backlog, post-outage collector buffer drains)
+          # holds large in-memory parts before flushing; 1Gi OOMKilled ~48s
+          # into the first backlog delivery
+          memory: 4Gi
       route:
         enabled: true
         hostnames: ["vlogs.ok8.sh"]


### PR DESCRIPTION
## What changed

Raises the victoria-logs server memory limit from 1Gi to 4Gi.

## Why

Follow-up to #5551: with the collector healthy, its month-of-backlog delivery OOMKilled the server ~48 seconds after each start. No parts had flushed durably yet (`smallParts: 0` on every restart), so the collector's disk buffer redelivered the same data into the next OOM — a cycle that never converges. Bulk ingest holds large in-memory parts before flushing; 1Gi (set in #5550) was sized for steady state, not catch-up.

## Reviewer notes

After merge the server should survive the backlog drain (expect elevated memory for a few minutes while the collector's disk buffer empties), then settle well under 1Gi. Node headroom is not a concern (~32GiB reserved beside the ZFS ARC cap; this pod's requests stay at 100m CPU).