### PR TITLE
Standardize Flux Kustomization intervals and grafana ks style

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -14,7 +14,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
   prune: true
   targetNamespace: *namespace
@@ -38,7 +38,7 @@ spec:
       namespace: external-secrets
     - name: openebs
       namespace: openebs-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true
   targetNamespace: *namespace

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -22,7 +22,7 @@ spec:
   dependsOn:
     - name: grafana-operator
       namespace: observability
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
   prune: true
   retryInterval: 1m

--- a/kubernetes/apps/custom-apps/apirouter/ks.yaml
+++ b/kubernetes/apps/custom-apps/apirouter/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/custom-apps/apirouter/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/custom-apps/apis/ks.yaml
+++ b/kubernetes/apps/custom-apps/apis/ks.yaml
@@ -18,6 +18,6 @@ spec:
   path: ./kubernetes/apps/custom-apps/apis/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/custom-apps/juno/ks.yaml
+++ b/kubernetes/apps/custom-apps/juno/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/custom-apps/juno/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/custom-apps/ok8-sh/ks.yaml
+++ b/kubernetes/apps/custom-apps/ok8-sh/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/custom-apps/ok8-sh/app
   prune: false
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/database/barman-cloud/ks.yaml
+++ b/kubernetes/apps/database/barman-cloud/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/database/barman-cloud/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -16,7 +16,7 @@ spec:
   path: ./kubernetes/apps/database/cloudnative-pg/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m
 ---
@@ -41,6 +41,6 @@ spec:
   path: ./kubernetes/apps/database/cloudnative-pg/clusters/immich
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -14,6 +14,6 @@ spec:
   path: ./kubernetes/apps/database/dragonfly/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/glance/ks.yaml
+++ b/kubernetes/apps/default/glance/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/default/glance/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -24,6 +24,6 @@ spec:
       KOPIUR_CACHE_CAPACITY: 5Gi
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/hytale/ks.yaml
+++ b/kubernetes/apps/default/hytale/ks.yaml
@@ -22,6 +22,6 @@ spec:
       KOPIUR_CACHE_CAPACITY: 25Gi
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -20,7 +20,7 @@ spec:
       KOPIUR_CACHE_CAPACITY: 10Gi
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m
 ---
@@ -37,6 +37,6 @@ spec:
     - name: immich
   path: ./kubernetes/apps/default/immich/frame
   prune: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/meshview/ks.yaml
+++ b/kubernetes/apps/default/meshview/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/default/meshview/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/mosquitto/ks.yaml
+++ b/kubernetes/apps/default/mosquitto/ks.yaml
@@ -22,6 +22,6 @@ spec:
       KOPIUR_CACHE_CAPACITY: 1Gi
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/music-assistant/ks.yaml
+++ b/kubernetes/apps/default/music-assistant/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/default/music-assistant/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/openspeedtest/ks.yaml
+++ b/kubernetes/apps/default/openspeedtest/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/default/openspeedtest/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/rtlamr2mqtt/ks.yaml
+++ b/kubernetes/apps/default/rtlamr2mqtt/ks.yaml
@@ -18,6 +18,6 @@ spec:
   path: ./kubernetes/apps/default/rtlamr2mqtt/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/survival/ks.yaml
+++ b/kubernetes/apps/default/survival/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/minecraft/survival/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/default/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/ks.yaml
@@ -22,6 +22,6 @@ spec:
       KOPIUR_CACHE_CAPACITY: 2Gi
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -25,7 +25,7 @@ spec:
   path: ./kubernetes/apps/external-secrets/external-secrets/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   targetNamespace: *namespace
   timeout: 5m

--- a/kubernetes/apps/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/ks.yaml
@@ -8,7 +8,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  interval: 30m
+  interval: 1h
   dependsOn:
     - name: external-secrets
   path: ./kubernetes/apps/external-secrets/onepassword/app

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/kube-system/cilium/app
   prune: false
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/kube-system/coredns/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
@@ -13,5 +13,5 @@ spec:
   path: ./kubernetes/apps/kube-system/intel-device-plugin/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/kube-system/metrics-server/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/kube-system/reloader/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/matrix/continuwuity/ks.yaml
+++ b/kubernetes/apps/matrix/continuwuity/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/matrix/continuwuity/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/matrix/dragonfly/ks.yaml
+++ b/kubernetes/apps/matrix/dragonfly/ks.yaml
@@ -14,6 +14,6 @@ spec:
   path: ./kubernetes/apps/matrix/dragonfly/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/matrix/hookshot/ks.yaml
+++ b/kubernetes/apps/matrix/hookshot/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/matrix/hookshot/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/matrix/meshtastic/ks.yaml
+++ b/kubernetes/apps/matrix/meshtastic/ks.yaml
@@ -16,6 +16,6 @@ spec:
   path: ./kubernetes/apps/matrix/meshtastic/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/networking/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/networking/cloudflare-dns/ks.yaml
@@ -24,6 +24,6 @@ spec:
   path: ./kubernetes/apps/networking/cloudflare-dns/app
   prune: false
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/networking/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/networking/cloudflare-tunnel/ks.yaml
@@ -22,6 +22,6 @@ spec:
   path: ./kubernetes/apps/networking/cloudflare-tunnel/app
   prune: false
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/networking/unifi-dns/ks.yaml
+++ b/kubernetes/apps/networking/unifi-dns/ks.yaml
@@ -24,6 +24,6 @@ spec:
   path: ./kubernetes/apps/networking/unifi-dns/app
   prune: false
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -13,5 +13,5 @@ spec:
   path: ./kubernetes/apps/observability/blackbox-exporter/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 15m

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -3,26 +3,35 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: grafana-operator
+  name: &app grafana-operator
+  namespace: &namespace observability
 spec:
-  interval: 1h
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/grafana/operator
   prune: true
-  targetNamespace: observability
   wait: true
+  interval: 1h
+  timeout: 5m
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: grafana
+  name: &app grafana
+  namespace: &namespace observability
 spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   dependsOn:
     - name: grafana-operator
-    #- name: rook-ceph-cluster
-    # namespace: rook-ceph
-  interval: 1h
+      namespace: *namespace
   path: ./kubernetes/apps/observability/grafana/instance
   prune: true
-  targetNamespace: observability
   wait: false
+  interval: 1h
+  timeout: 5m

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/observability/kromgo/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -16,5 +16,5 @@ spec:
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m

--- a/kubernetes/apps/observability/minecraft-exporter/ks.yaml
+++ b/kubernetes/apps/observability/minecraft-exporter/ks.yaml
@@ -16,5 +16,5 @@ spec:
   path: ./kubernetes/apps/observability/minecraft-exporter/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/observability/smartctl-exporter/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -16,5 +16,5 @@ spec:
   path: ./kubernetes/apps/observability/unpoller/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -13,7 +13,7 @@ spec:
   path: ./kubernetes/apps/observability/victoria-logs/app
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -33,5 +33,5 @@ spec:
   path: ./kubernetes/apps/observability/victoria-logs/collector
   prune: true
   wait: false
-  interval: 30m
+  interval: 1h
   timeout: 5m

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -13,6 +13,6 @@ spec:
   path: ./kubernetes/apps/openebs-system/openebs/app
   prune: true
   wait: true
-  interval: 30m
+  interval: 1h
   retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION
## What changed

- All 46 Flux Kustomizations using `interval: 30m` move to `1h`, matching the other 37. Nothing else in those files is touched.
- `grafana/ks.yaml` is rewritten into the repo's standard ks dialect: `&app`/`&namespace` anchors, `commonMetadata` labels, explicit `timeout: 5m`. Names, `wait` values, and the `dependsOn` relationship are unchanged. The commented-out `rook-ceph-cluster` dependsOn (upstream-template residue; no rook in this cluster) is gone.

## Why

The flux-instance webhook Receiver drives reconciliation on push, so intervals are only a drift-detection fallback; the 46/37 split had no rule behind it and the faster half just doubled background reconcile churn. The grafana file was the one ks predating the house style, and the missing `commonMetadata` labels meant its resources were the only ones not carrying `app.kubernetes.io/name`.

## Reviewer notes

- Kustomization names are deliberately untouched — renaming a Flux Kustomization prunes and recreates its resources.
- The new labels on grafana/grafana-operator resources will trigger one rolling restart of each on merge.
- `kustomize build` passes for every namespace dir.