### PR TITLE
Source metrics-server chart via OCIRepository

### DIFF
--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -1,11 +1,17 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+kind: OCIRepository
 metadata:
   name: metrics-server
 spec:
   interval: 1h
-  url: https://kubernetes-sigs.github.io/metrics-server
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.13.1
+  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -14,13 +20,9 @@ metadata:
   name: metrics-server
 spec:
   interval: 1h
-  chart:
-    spec:
-      chart: metrics-server
-      version: 3.13.1
-      sourceRef:
-        kind: HelmRepository
-        name: metrics-server
+  chartRef:
+    kind: OCIRepository
+    name: metrics-server
   install:
     remediation:
       retries: 3


### PR DESCRIPTION
## What changed

Replaces the metrics-server `HelmRepository` + `chart.spec` with an `OCIRepository` + `chartRef`, pulling the same 3.13.1 chart from `ghcr.io/home-operations/charts-mirror/metrics-server`.

## Why

This was the last chart-bearing HelmRepository in the repo — every other chart already uses an OCIRepository, so "chart source = OCIRepository" becomes an invariant instead of a convention with one exception. metrics-server doesn't publish an OCI chart upstream (`registry.k8s.io/metrics-server/charts/metrics-server` has no tags), so the mirror is the way to get there.

## Supply chain

The mirror is not a new dependency: `ghcr.io/home-operations/charts-mirror` already supplies cert-manager, openebs, and both external-dns instances in this repo. This adds a fifth consumer rather than a new trust relationship.

## Validation

- `helm template` output from the mirror is **byte-for-byte identical** to the same render from `https://kubernetes-sigs.github.io/metrics-server` at 3.13.1, using this repo's values. Pure source plumbing; no manifest changes reach the cluster.
- `kustomize build` passes.
- No renovate config change needed — OCI charts are already detected as container updates (cf. the existing `fix(container): update image ghcr.io/...helm...` commits), so metrics-server joins the same flow as every other chart.

## Reviewer note

Flux will swap the source object on merge and re-reconcile the HelmRelease; since the rendered manifests are identical, no metrics-server pod restart is expected beyond what the source swap itself triggers.