### PR TITLE
Fix README backup stack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The twist: nothing is configured by hand. The *entire* setup is written down as 
 - **[Cilium](https://cilium.io/) + BGP** — pods get routable IPs and LoadBalancer services are advertised straight to my UniFi router via BGP.
 - **[External DNS UniFi Webhook](https://github.com/kashalls/external-dns-unifi-webhook)** — a webhook I wrote so DNS records publish directly to UniFi, no extra resolvers.
 - **[Renovate](https://github.com/renovatebot/renovate)** — container images and Helm charts stay current through automated pull requests.
-- **[VolSync](https://volsync.readthedocs.io/) + ZFS** — persistent data is snapshotted and backed up off-site, on top of a dedicated [TrueNAS box](#-hardware).
+- **[Kopiur](https://github.com/home-operations/kopiur) + ZFS** — persistent volumes are ZFS-snapshotted and backed up off-site to Backblaze B2, with the bulk datasets (documents, projects, photo library) shipped to the same bucket on their own schedule.
 
 </details>
 


### PR DESCRIPTION
## What changed

Replaces the tech-stack bullet claiming **VolSync + ZFS ... on top of a dedicated TrueNAS box** with the architecture actually running: kopiur snapshotting PVCs to Backblaze B2, plus the weekly kopia job covering the hostPath datasets (documents, projects, immich library) to the same bucket.

## Why

VolSync is gone — its Kustomization was removed, and #5555 consolidated what remained into `kopiur-system`. B2 is the off-site target, not TrueNAS. This bullet is in the "for the technically curious" section at the top of the README, so it's the first architectural claim anyone reads, and it described a stack that no longer exists.

## Still stale, not touched here

The **Hardware** section likely needs your input rather than my inference:

- **Compute** lists *Minisforum MS-01 × 3 · 96 GB RAM · Talos / Kubernetes*, but the cluster is a single node (`puddle`, 64 CPU, 251 GiB RAM, Talos v1.13.5).
- **Storage** lists the *45HomeLab HL15 · 256 GB RAM · TrueNAS SCALE / ZFS*, but that box's specs match the Talos node itself — it appears to now *be* the cluster rather than a separate NAS.

I can't tell from the repo whether you still own the MS-01s or how you'd like the section framed, so I left it alone rather than guess at hardware facts.