### PR TITLE
Standardize OCIRepository intervals to 1h

### DIFF
--- a/kubernetes/apps/custom-apps/apis/app/ocirepository.yaml
+++ b/kubernetes/apps/custom-apps/apis/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: apis
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/custom-apps/juno/app/ocirepository.yaml
+++ b/kubernetes/apps/custom-apps/juno/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: juno
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/custom-apps/ok8-sh/app/ocirepository.yaml
+++ b/kubernetes/apps/custom-apps/ok8-sh/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: ok8-sh
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/home-assistant/app/ocirepository.yaml
+++ b/kubernetes/apps/default/home-assistant/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: home-assistant
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/meshview/app/ocirepository.yaml
+++ b/kubernetes/apps/default/meshview/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: meshview
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/mosquitto/app/ocirepository.yaml
+++ b/kubernetes/apps/default/mosquitto/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: mosquitto
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/music-assistant/app/ocirepository.yaml
+++ b/kubernetes/apps/default/music-assistant/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: music-assistant
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/opencloud/app/ocirepository.yaml
+++ b/kubernetes/apps/default/opencloud/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: opencloud
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/openspeedtest/app/ocirepository.yaml
+++ b/kubernetes/apps/default/openspeedtest/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: openspeedtest
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/rtlamr2mqtt/app/ocirepository.yaml
+++ b/kubernetes/apps/default/rtlamr2mqtt/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: rtlamr2mqtt
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/survival/app/ocirepository.yaml
+++ b/kubernetes/apps/default/survival/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: survival
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/syncthing/app/ocirepository.yaml
+++ b/kubernetes/apps/default/syncthing/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: syncthing
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/default/zigbee2mqtt/app/ocirepository.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: zigbee2mqtt
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/autobrr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/autobrr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: autobrr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/bazarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/bazarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: bazarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/brrpolice/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/brrpolice/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: brrpolice
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/flaresolverr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/flaresolverr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: flaresolverr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/kavita/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: kavita
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/mangarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: mangarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/plex/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/plex/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: plex
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/prowlarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/prowlarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: prowlarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/qbittorrent/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/qbittorrent/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: qbittorrent
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/qui/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/qui/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: qui
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/radarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/radarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: radarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/recyclarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/recyclarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: recyclarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/sabnzbd/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/sabnzbd/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: sabnzbd
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/seerr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/seerr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: seerr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/sonarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/sonarr/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: sonarr
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/suwayomi/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/suwayomi/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: suwayomi
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/tautulli/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/tautulli/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: tautulli
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/entertainment/thelounge/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/thelounge/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: thelounge
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/external-secrets/onepassword/app/ocirepository.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: onepassword
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: flux-instance
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: flux-operator
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: konflate
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: cilium
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: coredns
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: intel-device-plugin
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: reloader
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/matrix/continuwuity/app/ocirepository.yaml
+++ b/kubernetes/apps/matrix/continuwuity/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: continuwuity
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/matrix/hookshot/app/ocirepository.yaml
+++ b/kubernetes/apps/matrix/hookshot/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: hookshot
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/matrix/meshtastic/app/ocirepository.yaml
+++ b/kubernetes/apps/matrix/meshtastic/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: meshtastic
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/networking/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/cloudflare-dns/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: cloudflare-dns
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/networking/cloudflare-tunnel/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/cloudflare-tunnel/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: cloudflare-tunnel
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/networking/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/echo/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: echo
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/networking/multus/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/multus/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: multus
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/networking/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/unifi-dns/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: unifi-dns
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/blackbox-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: blackbox-exporter
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/gatus/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/gatus/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: gatus
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/grafana/operator/ocirepository.yaml
+++ b/kubernetes/apps/observability/grafana/operator/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: grafana-operator
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: kromgo
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: kube-prometheus-stack
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/minecraft-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/minecraft-exporter/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: minecraft-exporter
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: OCIRepository
 metadata:
   name: silence-operator
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: smartctl-exporter
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/snmp-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: snmp-exporter
 spec:
-  interval: 15m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: unpoller
 spec:
-  interval: 10m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: victoria-logs
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: victoria-logs-collector
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: openebs
 spec:
-  interval: 5m
+  interval: 1h
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy


### PR DESCRIPTION
## What changed

All 75 `OCIRepository` resources now use `interval: 1h`. Previously: 32 at `10m`, 15 at `15m`, 14 at `5m`, 14 already at `1h`. 60 files touched, interval lines only.

## Why

Every OCIRepository in the repo pins an exact chart tag — I checked, and there are **no semver ranges and no mutable tags** among them. So the interval governs nothing but re-polling a registry for an artifact that cannot change. Version bumps arrive as Renovate PRs, and Flux re-reads the source the moment a commit lands.

`1h` also makes the reconcile cadence uniform across the repo, matching the 83 Kustomizations standardized in #5554 and the 68 HelmReleases already at `1h`.

## Validation

- Doc-aware edit: only blocks with a top-level `kind: OCIRepository` were modified, so HelmReleases sharing a file (and their `chartRef.kind: OCIRepository` stanzas) are untouched.
- Diff is 60 insertions / 60 deletions with **zero** non-`interval` lines.
- `kustomize build` passes for every namespace.

## Noted, not changed

Seven HelmReleases are still interval outliers (3 at `30m`, 3 at `5m`, 1 at `15m`) against 68 at `1h`. Left alone in case any is deliberate — happy to fold them in if you'd rather they match.