### PR TITLE
Move workloads off the failed local-hostpath disk

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/clusters/immich/postgres.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/clusters/immich/postgres.yaml
@@ -18,7 +18,7 @@ spec:
 
   storage:
     size: 15Gi
-    storageClass: openebs-hostpath
+    storageClass: openebs-zfs-luddle
 
   enableSuperuserAccess: true
   superuserSecret:
@@ -49,7 +49,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: immich
-        serverName: &currentServer immich
+        serverName: &currentServer immich-v2
 
   bootstrap:
     recovery:

--- a/kubernetes/apps/default/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/music-assistant/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 5Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle
         advancedMounts:
           music-assistant:
             app:

--- a/kubernetes/apps/default/opencloud/app/helmrelease.yaml
+++ b/kubernetes/apps/default/opencloud/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 15Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle
         globalMounts:
           - path: /var/lib/opencloud
             subPath: data

--- a/kubernetes/apps/default/survival/app/helmrelease.yaml
+++ b/kubernetes/apps/default/survival/app/helmrelease.yaml
@@ -92,4 +92,4 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 50Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle

--- a/kubernetes/apps/matrix/continuwuity/app/helmrelease.yaml
+++ b/kubernetes/apps/matrix/continuwuity/app/helmrelease.yaml
@@ -138,7 +138,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 5Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle
         globalMounts:
           - path: *data
       extra:

--- a/kubernetes/apps/matrix/hookshot/app/helmrelease.yaml
+++ b/kubernetes/apps/matrix/hookshot/app/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 5Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle
         globalMounts:
           - path: /data
             subPath: data

--- a/kubernetes/apps/matrix/meshtastic/app/helmrelease.yaml
+++ b/kubernetes/apps/matrix/meshtastic/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 5Gi
-        storageClass: openebs-hostpath
+        storageClass: openebs-zfs-luddle
         globalMounts:
           - path: /app/data
             subPath: data

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       hostpathClass:
         enabled: true
         name: openebs-hostpath
-        isDefaultClass: true
+        isDefaultClass: false
         basePath: *basePath
       helperPod:
         image:

--- a/kubernetes/apps/openebs-system/openebs/app/storageclass-luddle.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/storageclass-luddle.yaml
@@ -4,6 +4,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: openebs-zfs-luddle
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: zfs.csi.openebs.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -21,7 +21,7 @@ spec:
     cache:
       capacity: ${KOPIUR_CACHE_CAPACITY:=5Gi}
       mode: Persistent
-      storageClassName: ${KOPIUR_CACHE_STORAGECLASS:=openebs-hostpath}
+      storageClassName: ${KOPIUR_CACHE_STORAGECLASS:=openebs-zfs-luddle}
     podSecurityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}


### PR DESCRIPTION
## Why

The XFS filesystem backing `openebs-hostpath` shut down at **2026-08-17 12:27 UTC** and returns `input/output error` on every operation. It is `/dev/nvme0n1p1` — a Talos UserVolume on disk serial `S64GNE0R817067` (Samsung PM9A3), mounted at `/var/mnt/local-hostpath`.

Evidence it is the filesystem and not the hardware:
- All 13 drives are SMART-clean — 0 media errors, 0 critical warnings, 100% available spare, 8-9% wear on the PM9A3s.
- `node_filesystem_avail_bytes` has been frozen at one exact value since 12:27 UTC while varying normally before it — the classic XFS shutdown signature (mounted, but every I/O returns EIO).
- This is the same volume implicated in the July `xfs log deadlock` that got Loki disabled, so it is a recurrence.

## What changed

**immich postgres → ZFS, recovered from backup.** `storageClass` moves to `openebs-zfs-luddle`. The cluster already had `bootstrap.recovery` wired to the barman ObjectStore, so recreating it restores from B2. Its **archive `serverName` moves to `immich-v2`** while the recovery source stays `immich` — otherwise the recovered cluster would archive WAL over the very backup it bootstrapped from.

**kopiur mover caches → ZFS.** `KOPIUR_CACHE_STORAGECLASS` now defaults to `openebs-zfs-luddle`, moving 23 cache PVCs off the disk.

**Default storage class → ZFS.** `hostpathClass.isDefaultClass` becomes `false` and `openebs-zfs-luddle` gains the default annotation, so nothing new provisions onto a disk that is being removed.

**Six remaining `openebs-hostpath` references** (music-assistant, opencloud, survival, continuwuity, meshtastic, hookshot) flipped to ZFS. None currently have PVCs, so this is purely preventative.

`luddle` is confirmed to be on different physical disks: it reports 1.83 TB usable while the failed XFS consumes the full 1.92 TB of `S64GNE0R817067`.

## Blast radius today

24 PVCs sit on the dead filesystem: 23 disposable `kopiur-cache-*`, plus `database/immich-1`. immich's postgres is logging `could not seek to end of file "global/1262"` and `could not open file "global/pg_filenode.map"` — it cannot read its own catalogs, though the pod still reports `2/2 Running`, which is why nothing alerted.

immich's **media library is unaffected** — it lives on ZFS at `/var/mnt/puddle/kubernetes/immich`. Only the database is involved, and the last barman backup completed 03:00 UTC on 2026-08-17, about nine hours before the failure, with continuous WAL archiving healthy up to that point.

## Rollout (manual, after merge)

This PR alone does not migrate anything — CNPG cannot change the storage class of an existing cluster in place. After merge:

1. Verify the B2 backup is restorable.
2. Delete the `Cluster/immich` object so Flux recreates it; it will provision on ZFS and bootstrap via recovery.
3. Clear the stuck kopiur Snapshots and their `kopiur-cache-*` PVCs so they re-provision on ZFS.

## Still to do for disk removal

Not included here, deliberately: removing the `local-hostpath` UserVolumeConfig from `talos/nodes/10.0.10.40.yaml` and disabling `hostpathClass` entirely. Both should wait until immich is confirmed recovered and no PVCs remain on the volume.