### PR TITLE
Remove the local-hostpath volume and its storage class

### DIFF
--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -38,12 +38,8 @@ spec:
       localpv:
         image:
           registry: quay.io/
-        basePath: &basePath /var/mnt/local-hostpath
       hostpathClass:
-        enabled: true
-        name: openebs-hostpath
-        isDefaultClass: true
-        basePath: *basePath
+        enabled: false
       helperPod:
         image:
           registry: quay.io/

--- a/talos/nodes/10.0.10.40.yaml
+++ b/talos/nodes/10.0.10.40.yaml
@@ -36,14 +36,6 @@ vlanID: 30
 mtu: 9000
 ---
 apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: local-hostpath
-provisioning:
-  diskSelector:
-    match: disk.serial == "S64GNE0R817067" && !system_disk
-  minSize: 1TB
----
-apiVersion: v1alpha1
 kind: WatchdogTimerConfig
 device: /dev/watchdog0
 timeout: 5m


### PR DESCRIPTION
## ⚠️ Merge order

**This must merge after #5562, and only once no PVCs remain on `openebs-hostpath`.**

#5562 moves immich and the kopiur caches to ZFS and makes `openebs-zfs-luddle` the default class. Merging this one first would leave the cluster with **no default StorageClass** while immich is still bound to `openebs-hostpath`. Pre-merge check:

```
kubectl get pvc -A -o json | jq -r '[.items[]|select(.spec.storageClassName=="openebs-hostpath")]|length'
```

That must return `0`.

## What changed

- **`talos/nodes/10.0.10.40.yaml`** — drops the `UserVolumeConfig` provisioning `local-hostpath` from disk serial `S64GNE0R817067`. The remaining 7 documents (machine config, hostname, link alias, bond, DHCP, VLAN, watchdog) parse cleanly and are untouched.
- **openebs helmrelease** — `hostpathClass.enabled: false`, and the now-unreferenced `basePath` anchor is dropped. The umbrella chart has no `engines.local.hostpath` toggle, so `hostpathClass.enabled` is the supported way to stop the class being created.

## Why

The XFS filesystem on that disk shut down at **2026-08-17 12:27 UTC**, returning EIO on every operation, and took immich's postgres and 23 kopiur caches with it. It is the second failure on this volume — it was also behind the July `xfs log deadlock` that got Loki disabled — on hardware SMART reports as perfectly healthy (0 media errors, 100% spare, 8-9% wear).

## After merge

Removing the `UserVolumeConfig` stops Talos provisioning and mounting the volume, but **does not wipe the partition**. The disk still physically holds the old XFS partition, so pulling the drive (or wiping it) is a separate manual step once the node is rebooted and you have confirmed nothing needs it.

A node reboot is required regardless — an XFS shutdown only clears on remount, and this is a single-node cluster, so that is a full outage to schedule rather than stumble into.