### PR TITLE
feat(entertainment): add chaski, cleanrr and agregarr

### DIFF
--- a/kubernetes/apps/entertainment/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/agregarr/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agregarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: agregarr
+  interval: 1h
+  values:
+    controllers:
+      agregarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/agregarr/agregarr
+              tag: v2.4.2@sha256:5f1390bc43fefbbfb67f38a7a8dd65b4086c1f187a37c8df5c6020a498e5d1b5
+            env:
+              PORT: &port 80
+              TZ: America/Los_Angeles
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/status
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.ok8.sh"
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: agregarr-zfs
+        globalMounts:
+          - path: /app/config
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/entertainment/agregarr/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/agregarr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./pvc-zfs.yaml

--- a/kubernetes/apps/entertainment/agregarr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/agregarr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agregarr
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/agregarr/app/pvc-zfs.yaml
+++ b/kubernetes/apps/entertainment/agregarr/app/pvc-zfs.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/storage.k8s.io/persistentvolumeclaim_v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agregarr-zfs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: openebs-zfs-luddle

--- a/kubernetes/apps/entertainment/agregarr/ks.yaml
+++ b/kubernetes/apps/entertainment/agregarr/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agregarr
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/agregarr/app
+  components:
+    - ../../../../components/kopiur/backup
+  postBuild:
+    substitute:
+      APP: agregarr-zfs
+      KOPIUR_CACHE_CAPACITY: 5Gi
+  prune: true
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/entertainment/chaski/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/chaski/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: chaski
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: chaski-secret
+    template:
+      data:
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        RADARR_PUSHOVER_TOKEN: "{{ .RADARR_PUSHOVER_TOKEN }}"
+        SONARR_PUSHOVER_TOKEN: "{{ .SONARR_PUSHOVER_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: pushover
+    - extract:
+        key: radarr
+    - extract:
+        key: sonarr

--- a/kubernetes/apps/entertainment/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/chaski/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chaski
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: chaski
+  interval: 1h
+  values:
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    env:
+      TZ: America/Los_Angeles
+    envFrom:
+      - secretRef:
+          name: chaski-secret
+    config:
+      targets:
+        radarr:
+          apprise:
+            url: pover://{{ env "PUSHOVER_USER_KEY" }}@{{ env "RADARR_PUSHOVER_TOKEN" }}
+        sonarr:
+          apprise:
+            url: pover://{{ env "PUSHOVER_USER_KEY" }}@{{ env "SONARR_PUSHOVER_TOKEN" }}
+      routes:
+        radarr-download:
+          target: radarr
+          title: Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}
+          message: |-
+            <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
+            <small>{{ .payload.movie.overview | ellipsis 300 }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+          params:
+            format: html
+            priority: low
+            url: "{{ .payload.applicationUrl }}/movie/{{ .payload.movie.tmdbId }}"
+            url_title: View Movie
+          whenExpr: payload.eventType == "Download"
+        radarr-manual:
+          target: radarr
+          title: Movie Requires Manual Interaction
+          message: |-
+            <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+          params:
+            format: html
+            priority: high
+            url: "{{ .payload.applicationUrl }}/activity/queue"
+            url_title: View Queue
+          whenExpr: payload.eventType == "ManualInteractionRequired"
+        sonarr-download:
+          target: sonarr
+          title: Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}
+          message: |-
+            <b>{{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})</b>
+            <small>{{ (index .payload.episodes 0).title }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+          params:
+            format: html
+            priority: low
+            url: "{{ .payload.applicationUrl }}/series/{{ .payload.series.titleSlug }}"
+            url_title: View Series
+          whenExpr: payload.eventType == "Download"
+        sonarr-manual:
+          target: sonarr
+          title: Episode Requires Manual Interaction
+          message: |-
+            <b>{{ .payload.series.title }}</b>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+          params:
+            format: html
+            priority: high
+            url: "{{ .payload.applicationUrl }}/activity/queue"
+            url_title: View Queue
+          whenExpr: payload.eventType == "ManualInteractionRequired"
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/entertainment/chaski/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/chaski/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/chaski/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: chaski
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.5.0
+  url: oci://ghcr.io/home-operations/charts/chaski

--- a/kubernetes/apps/entertainment/chaski/ks.yaml
+++ b/kubernetes/apps/entertainment/chaski/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app chaski
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/chaski/app
+  prune: true
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/entertainment/cleanrr/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/cleanrr/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cleanrr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cleanrr-secret
+    template:
+      data:
+        CLEANRR_SERVERS__RADARR__API_KEY: "{{ .RADARR_API_KEY }}"
+        CLEANRR_SERVERS__SONARR__API_KEY: "{{ .SONARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: radarr
+    - extract:
+        key: sonarr

--- a/kubernetes/apps/entertainment/cleanrr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/cleanrr/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cleanrr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cleanrr
+  interval: 1h
+  values:
+    controllers:
+      cleanrr:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/zariel/cleanrr
+              tag: v0.1.6@sha256:ff5de090d4295a56cedd8c8167d0e5b070970d3ca304090d36001c922fc8a2d0
+            env:
+              CLEANRR_LISTEN_ADDR: 0.0.0.0:80
+              CLEANRR_MINIMUM_AGE: 5m
+              CLEANRR_SERVERS__RADARR__URL: http://radarr.entertainment.svc.cluster.local
+              CLEANRR_SERVERS__SONARR__URL: http://sonarr.entertainment.svc.cluster.local
+              TZ: America/Los_Angeles
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/live
+                    port: &port 80
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/ready
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/startup
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http

--- a/kubernetes/apps/entertainment/cleanrr/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/cleanrr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/cleanrr/app/ocirepository.yaml
+++ b/kubernetes/apps/entertainment/cleanrr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cleanrr
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/entertainment/cleanrr/ks.yaml
+++ b/kubernetes/apps/entertainment/cleanrr/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cleanrr
+  namespace: &namespace entertainment
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/entertainment/cleanrr/app
+  prune: true
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -8,9 +8,12 @@ components:
 replacements:
   - path: ../../components/replacements/ks.yaml
 resources:
+  - ./agregarr/ks.yaml
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./chaski/ks.yaml
+  - ./cleanrr/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./kavita/ks.yaml
   - ./mangarr/ks.yaml


### PR DESCRIPTION
Adds three *arr companion apps, ported from [onedr0p/home-ops](https://github.com/onedr0p/home-ops):

- **chaski** — stateless webhook relay; turns Radarr/Sonarr `Download` and `ManualInteractionRequired` events into Pushover notifications. Chart `ghcr.io/home-operations/charts/chaski` 0.5.0.
- **cleanrr** — prunes stalled grabs from Radarr and Sonarr. `ghcr.io/zariel/cleanrr:v0.1.6`.
- **agregarr** — Plex collections manager (Trakt/IMDb/TMDB/Letterboxd lists, Tautulli stats, Overseerr requests). `ghcr.io/agregarr/agregarr:v2.4.2`.

## Adaptations from upstream

- Namespaced to `entertainment` rather than `default`, so cleanrr's `radarr.entertainment.svc.cluster.local` / `sonarr.entertainment.svc.cluster.local` URLs resolve and the apps sit with plex/tautulli/seerr.
- `TZ: America/Los_Angeles`, schema comments on `kubernetes-schemas.ok8.sh`, ClusterSecretStore `onepassword`.
- agregarr's route is `agregarr.ok8.sh` on the `internal` gateway in `networking`, `sectionName: https`.
- chaski runs one replica instead of two — a second buys no availability on a single-node cluster.
- agregarr gets its own `agregarr-zfs` PVC (5Gi, `openebs-zfs-luddle`) plus the `kopiur/backup` component, matching radarr/qui. Upstream's `zeroscaler` component was dropped; this repo removed it in #5553.

## Validation

`kustomize build` on the namespace and each app dir, `helm template` of all three charts against their real values, and `kubeconform -strict` over the rendered output — all clean. Both image digests were resolved fresh from ghcr and match the tags pinned here; 0.5.0 and v0.1.6 and v2.4.2 are the current releases.

## Follow-up needed before these will come up

1. The chaski ExternalSecret pulls `RADARR_PUSHOVER_TOKEN` from the `radarr` 1Password item and `SONARR_PUSHOVER_TOKEN` from `sonarr`. Neither field exists yet — add them (separate Pushover application tokens give each *arr its own notification icon). `PUSHOVER_USER_KEY` already comes from the existing `pushover` item.
2. chaski routes by URL path, so Radarr and Sonarr each need two Webhook connections: `http://chaski.entertainment.svc.cluster.local:8080/hooks/{radarr,sonarr}-download` and `.../hooks/{radarr,sonarr}-manual`.
3. agregarr needs first-run setup through its web UI.